### PR TITLE
make simpletest show the image

### DIFF
--- a/examples/imageload_simpletest.py
+++ b/examples/imageload_simpletest.py
@@ -1,6 +1,15 @@
+import board
 import displayio
 import adafruit_imageload
 
 image, palette = adafruit_imageload.load(
     "images/4bit.bmp", bitmap=displayio.Bitmap, palette=displayio.Palette
 )
+tile_grid = displayio.TileGrid(image, pixel_shader=palette)
+
+group = displayio.Group()
+group.append(tile_grid)
+board.DISPLAY.show(group)
+
+while True:
+    pass


### PR DESCRIPTION
This solves #30 

The simpletest script has been modified to also create a group and show it on the built-in display, as well as have a main loop with `pass` so that it will keep showing until stopped by `KeyboardInterrupt`