### PR TITLE
Fix for builds without longint

### DIFF
--- a/adafruit_imageload/bmp/__init__.py
+++ b/adafruit_imageload/bmp/__init__.py
@@ -50,7 +50,12 @@ def load(file, *, bitmap=None, palette=None):
     # print(bmp_header_length)
     file.seek(0x12)  # Width of the bitmap in pixels
     width = int.from_bytes(file.read(4), "little")
-    height = int.from_bytes(file.read(4), "little")
+    try:
+        height = int.from_bytes(file.read(4), "little")
+    except OverflowError:
+        raise NotImplementedError(
+            "Negative height BMP files are not supported on builds without longint"
+        )
     file.seek(0x1C)  # Number of bits per pixel
     color_depth = int.from_bytes(file.read(2), "little")
     file.seek(0x1E)  # Compression type

--- a/adafruit_imageload/bmp/indexed.py
+++ b/adafruit_imageload/bmp/indexed.py
@@ -73,12 +73,9 @@ def load(
         while colors > 2 ** minimum_color_depth:
             minimum_color_depth *= 2
 
-        # convert unsigned int to signed int when height is negative
         if sys.maxsize > 1073741823:
             # pylint: disable=import-outside-toplevel
             from .negative_height_check import negative_height_check
-
-            height = height - 4294967296
 
             # convert unsigned int to signed int when height is negative
             height = negative_height_check(height)

--- a/adafruit_imageload/bmp/indexed.py
+++ b/adafruit_imageload/bmp/indexed.py
@@ -32,6 +32,8 @@ Load pixel values (indices or colors) into a bitmap and colors into a palette fr
 __version__ = "0.0.0-auto.0"
 __repo__ = "https://github.com/adafruit/Adafruit_CircuitPython_ImageLoad.git"
 
+import sys
+
 
 def load(
     file,
@@ -72,8 +74,14 @@ def load(
             minimum_color_depth *= 2
 
         # convert unsigned int to signed int when height is negative
-        if height > 0x7FFFFFFF:
+        if sys.maxsize > 1073741823:
+            # pylint: disable=import-outside-toplevel
+            from .negative_height_check import negative_height_check
+
             height = height - 4294967296
+
+            # convert unsigned int to signed int when height is negative
+            height = negative_height_check(height)
         bitmap = bitmap(width, abs(height), colors)
         file.seek(data_start)
         line_size = width // (8 // color_depth)

--- a/adafruit_imageload/bmp/negative_height_check.py
+++ b/adafruit_imageload/bmp/negative_height_check.py
@@ -1,0 +1,12 @@
+"""
+Check for negative height on the BMP.
+Seperated into it's own file to support builds
+without longint.
+"""
+
+
+def negative_height_check(height):
+    """Check the height return modified if negative."""
+    if height > 0x7FFFFFFF:
+        return height - 4294967296
+    return height


### PR DESCRIPTION
Closes #28

This change refactors negative height check into its own file in order to avoid using `0x7FFFFFFF` altogether on builds without longint. This allows it to avoid a seemingly un-catchable overflow error. 

I am very open to other ways to achieve this library working on devices without longint and continuing to work correctly with negative height bmp files on builds that do have longint. This was the only thing I managed to come up with that was working.

If you try to use load a negative bmp on a build without longint now you get this error:
```
code.py output:
Traceback (most recent call last):
  File "code.py", line 7, in <module>
  File "/lib/adafruit_imageload/__init__.py", line 61, in load
  File "/lib/adafruit_imageload/__init__.py", line 52, in load
  File "/lib/adafruit_imageload/bmp/__init__.py", line 57, in load
NotImplementedError: Negative height BMP files are not supported on builds without longint
```

If you load  a negative bmp on a build with longint it will correctly show the image.

These changes were tested on EdgeBadge and PewPew M4 respectively using the image file linked in #18