### PR TITLE
add sub packages to setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -46,5 +46,5 @@ setup(
     keywords="adafruit blinka circuitpython micropython bitmap fonts text display tft lcd displayio imageload image",
     # You can just specify the packages manually here if your project is
     # simple. Or you can use find_packages().
-    packages=["adafruit_imageload"],
+    packages=["adafruit_imageload", "adafruit_imageload.bmp", "adafruit_imageload.pnm"],
 )


### PR DESCRIPTION
It seemed that pip install was broken due to installing without the sub packages `bmp` and `pnm`. 

Adding them in `setup.py` resolves this for me. Now I can do `pip install .` in the repo and I will end up with a working imageload module being installed.