### PR TITLE
Add option for using bitmaptools.readinto for indexed bitmap loads

### DIFF
--- a/adafruit_imageload/bmp/indexed.py
+++ b/adafruit_imageload/bmp/indexed.py
@@ -86,7 +86,6 @@ def load(
             range3 = 1
 
         if compression == 0:
-            chunk = bytearray(line_size)
 
             if _bitmap_readinto:
                 _bitmap_readinto(
@@ -98,6 +97,7 @@ def load(
                     reverse_rows=True,
                 )
             else:  # use the standard file.readinto
+                chunk = bytearray(line_size)
                 for y in range(range1, range2, range3):
                     file.readinto(chunk)
                     pixels_per_byte = 8 // color_depth

--- a/adafruit_imageload/bmp/indexed.py
+++ b/adafruit_imageload/bmp/indexed.py
@@ -166,7 +166,6 @@ def decode_rle(bitmap, file, compression, y_range, width):
         # file is 15px wide but has data for 16px.
         width_remaining = width - x
 
-        print("doing this too")
         file.readinto(run_buf)
 
         if run_buf[0] == 0:


### PR DESCRIPTION
This adds an option to use the new `bitmaptools.readinto` function.  I observed a 4x speedup when loading a 320x240 pixel bitmap.

Since some graphics bitmap files are read in different row directions, this library update requires one addition to the `bitmaptools.readinto` function to add `reverse_rows`, from this PR: https://github.com/adafruit/circuitpython/pull/4428

Also, see this comment from @jepler that mentions the row direction of BMP files: https://github.com/adafruit/circuitpython/pull/4403#issuecomment-799433379