### PR TITLE
readinto fallback for missing argument

### DIFF
--- a/adafruit_imageload/bmp/indexed.py
+++ b/adafruit_imageload/bmp/indexed.py
@@ -99,9 +99,9 @@ def load(
                     )
                 except TypeError:
                     # catch unexpected argument, try python read code.
-                    # this can be removed after a release is made that
-                    # includes bitmapttools.readinto() with all arguments
-                    # used above.
+                    # This issue affects only CircuitPython 6.2.0-beta.4.
+                    # The try/except block here should be removed when
+                    # a newer release is made.
                     chunk = bytearray(line_size)
                     for y in range(range1, range2, range3):
                         file.readinto(chunk)


### PR DESCRIPTION
This resolves the first issue mentioned in  #47. 

The current released versions of CircuitPython do contain `readinto()` but do not contain all of the arguments that this library is trying to use. (CircuitPython main branch does include all of the arguments, it appears some were merged in after the release).

This changes catches the unexpected argument error and falls back to attempting the python file read method of loading the image.

This could be removed once we have a release that does include those arguments that are in use in this library.

I tested these changes with the simpletest script in this repo on:
```
Adafruit CircuitPython 6.2.0-beta.4 on 2021-03-18; Adafruit Feather RP2040 with rp2040
```
With the changes from this PR I am able to run the simpletest successfully and have it show the image, instead of raising the error.