### PR TITLE
BytesIO support

### DIFF
--- a/adafruit_imageload/__init__.py
+++ b/adafruit_imageload/__init__.py
@@ -39,7 +39,11 @@ def load(filename, *, bitmap=None, palette=None):
             # meh, we tried
             pass
 
-    with open(filename, "rb") as file:
+    file_or_filename = filename
+    if isinstance(file_or_filename, str):
+        file_or_filename = open(filename, "rb")
+
+    with file_or_filename as file:
         header = file.read(3)
         file.seek(0)
         if header.startswith(b"BM"):

--- a/adafruit_imageload/__init__.py
+++ b/adafruit_imageload/__init__.py
@@ -17,7 +17,7 @@ __version__ = "0.0.0-auto.0"
 __repo__ = "https://github.com/adafruit/Adafruit_CircuitPython_ImageLoad.git"
 
 
-def load(filename, *, bitmap=None, palette=None):
+def load(file_or_filename, *, bitmap=None, palette=None):
     """Load pixel values (indices or colors) into a bitmap and colors into a palette.
 
     bitmap is the desired type. It must take width, height and color_depth in the constructor. It
@@ -39,11 +39,12 @@ def load(filename, *, bitmap=None, palette=None):
             # meh, we tried
             pass
 
-    file_or_filename = filename
     if isinstance(file_or_filename, str):
-        file_or_filename = open(filename, "rb")
+        open_file = open(file_or_filename, "rb")
+    else:
+        open_file = file_or_filename
 
-    with file_or_filename as file:
+    with open_file as file:
         header = file.read(3)
         file.seek(0)
         if header.startswith(b"BM"):

--- a/docs/examples.rst
+++ b/docs/examples.rst
@@ -6,3 +6,12 @@ Ensure your image loads with this simple test.
 .. literalinclude:: ../examples/imageload_simpletest.py
     :caption: examples/imageload_simpletest.py
     :linenos:
+
+Requests test
+-------------
+
+Loads image that is fetched using adafruit_request
+
+.. literalinclude:: ../examples/imageload_from_web.py
+    :caption: examples/imageload_from_web.py
+    :linenos:

--- a/examples/imageload_from_web.py
+++ b/examples/imageload_from_web.py
@@ -1,0 +1,49 @@
+# SPDX-FileCopyrightText: 2021 Tim C for Adafruit Industries
+# SPDX-License-Identifier: MIT
+"""
+imageload example for esp32s2 that loads an image fetched via
+adafruit_requests using BytesIO
+"""
+from io import BytesIO
+import ssl
+import wifi
+import socketpool
+
+import board
+import displayio
+import adafruit_requests as requests
+import adafruit_imageload
+
+# Get wifi details and more from a secrets.py file
+try:
+    from secrets import secrets
+except ImportError:
+    print("WiFi secrets are kept in secrets.py, please add them there!")
+    raise
+
+wifi.radio.connect(secrets["ssid"], secrets["password"])
+
+print("My IP address is", wifi.radio.ipv4_address)
+
+socket = socketpool.SocketPool(wifi.radio)
+https = requests.Session(socket, ssl.create_default_context())
+
+# pylint: disable=line-too-long
+url = "https://raw.githubusercontent.com/adafruit/Adafruit_CircuitPython_ImageLoad/main/examples/images/4bit.bmp"
+
+print("Fetching text from %s" % url)
+response = https.get(url)
+print("GET complete")
+
+bytes_img = BytesIO(response.content)
+image, palette = adafruit_imageload.load(bytes_img)
+tile_grid = displayio.TileGrid(image, pixel_shader=palette)
+
+group = displayio.Group(scale=1)
+group.append(tile_grid)
+board.DISPLAY.show(group)
+
+response.close()
+
+while True:
+    pass


### PR DESCRIPTION
resolves #51 and originally stemmed from [#4831](https://github.com/adafruit/circuitpython/issues/4831)

These changes begin the process of adding support for BytesIO (and possibly other "file-like" objects).

In order to achieve full support for this on modern versions we will need to modify bitmap.readinto() in the core to be able to work with file-like objects.

I was able to successfully test this using the python readinto code from here:
https://github.com/adafruit/Adafruit_CircuitPython_ImageLoad/blob/681a60401c0ae3f44a5bd14e06bb8cb384aa2991/adafruit_imageload/bmp/indexed.py#L118

For the purposes of testing I just modified the if statement to force it to use the python readinto code instead of the core bitmaptools.readinto(). My test was run on a FunHouse with `7.0.0-alpha.3` and it did show the downloaded image.

As-is in the core this line ends up raising a TypeError:

https://github.com/adafruit/circuitpython/blob/5f81f9ed1cb9ba98436ebdc54756ef1702681703/shared-bindings/bitmaptools/__init__.c#L479

So for full support we'll need to modify that check and the code that comes after it to be okay with accepting a BytesIO object instead of a file. I poked around with this for a bit, but the C code in question is a bit beyond my capabilities at this point. @jepler I think you may have written this function originally do you have any thoughts on whether it would be possible to modify it to accept BytesIO in addition to file type objects?