### PR TITLE
Remove max_size parameter

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,8 @@ bundles
 venv/
 .vscode
 .DS_STORE
+develop-eggs/
+eggs/
+.eggs/
+*.egg-info/
+*.egg

--- a/examples/imageload_netpbm.py
+++ b/examples/imageload_netpbm.py
@@ -27,7 +27,7 @@ display_bus = displayio.FourWire(spi, command=tft_dc, chip_select=tft_cs)
 display = adafruit_ili9341.ILI9341(display_bus, width=320, height=240)
 
 # Make the display context
-splash = displayio.Group(max_size=10)
+splash = displayio.Group()
 display.show(splash)
 # image = "images/netpbm_p1_mono_ascii.pbm"
 # image = "images/netpbm_p2_ascii.pgm"


### PR DESCRIPTION
Remove the `max_size` parameter. It is no longer used by `displayio.Group`
Ref: adafruit/circuitpython#4959

Updated example tested on a Pynt (with modifications for PyPortal screen):
```
Adafruit CircuitPython 6.3.0 on 2021-06-01; Adafruit PyPortal with samd51j20
```