### PR TITLE
CircuitPython 7 no longer allows StopIteration fallback

### DIFF
--- a/adafruit_imageload/gif.py
+++ b/adafruit_imageload/gif.py
@@ -137,17 +137,20 @@ def lzw_decode(data, code_size):
     """Decode LZW-compressed data."""
     dictionary = LZWDict(code_size)
     bit = 0
-    byte = next(data)  # pylint: disable=stop-iteration-return
     try:
-        while True:
-            code = 0
-            for i in range(dictionary.code_len):
-                code |= ((byte >> bit) & 0x01) << i
-                bit += 1
-                if bit >= 8:
-                    bit = 0
-                    byte = next(data)  # pylint: disable=stop-iteration-return
-            yield dictionary.decode(code)
-    except EndOfData:
-        while True:
-            next(data)  # pylint: disable=stop-iteration-return
+        byte = next(data)  # pylint: disable=stop-iteration-return
+        try:
+            while True:
+                code = 0
+                for i in range(dictionary.code_len):
+                    code |= ((byte >> bit) & 0x01) << i
+                    bit += 1
+                    if bit >= 8:
+                        bit = 0
+                        byte = next(data)  # pylint: disable=stop-iteration-return
+                yield dictionary.decode(code)
+        except EndOfData:
+            while True:
+                next(data)  # pylint: disable=stop-iteration-return
+    except StopIteration:
+        pass

--- a/tests/displayio_shared_bindings.py
+++ b/tests/displayio_shared_bindings.py
@@ -211,6 +211,6 @@ class Palette_C_Interface:
         print(str(palette))
         """
         out = "\nPalette:\n"
-        for y in range(len(self.colors)):
-            out += f" [{y}] {self.colors[y]}\n"
+        for i, color in enumerate(self.colors):
+            out += f" [{i}] {color}\n"
         return out

--- a/tests/test_bitmap_c_interface.py
+++ b/tests/test_bitmap_c_interface.py
@@ -41,7 +41,7 @@ class TestBitmap_C_Interface(TestCase):
 
     def test_abs(self):
         b = Bitmap_C_Interface(5, 2, 1)
-        self.assertEqual(9, b._abs_pos(4, 1))
+        self.assertEqual(9, b._abs_pos(4, 1))  # pylint: disable=protected-access
 
     def test_set_tuple(self):
         b = Bitmap_C_Interface(2, 4, 1)
@@ -65,11 +65,8 @@ class TestBitmap_C_Interface(TestCase):
 
     def test_throws_x_out_of_range(self):
         b = Bitmap_C_Interface(2, 4, 1)
-        try:
+        with self.assertRaises(ValueError):
             b[2, 1] = 100
-            self.fail("should have thrown")
-        except ValueError:
-            pass
 
     def test_max(self):
         b = Bitmap_C_Interface(2, 4, 1)
@@ -78,18 +75,13 @@ class TestBitmap_C_Interface(TestCase):
 
     def test_uninitialized(self):
         b = Bitmap_C_Interface(2, 4, 1)
-        try:
-            b[1, 1]
-            self.fail("should have thrown")
-        except RuntimeError:
-            pass
+        with self.assertRaises(RuntimeError):
+            b[1, 1]  # pylint: disable=pointless-statement
 
     def test_validate_throws(self):
         b = Bitmap_C_Interface(2, 4, 1)
-        try:
+        with self.assertRaises(ValueError):
             b.validate()
-        except ValueError:
-            pass
 
     def test_repr(self):
         b = Bitmap_C_Interface(3, 2, 1)
@@ -103,6 +95,6 @@ class TestBitmap_C_Interface(TestCase):
 
     def test_decode(self):
         b = Bitmap_C_Interface(4, 4, 1)
-        self.assertEqual((0, 0), b._decode(0))
-        encoded = b._abs_pos(3, 3)
-        self.assertEqual((3, 3), b._decode(encoded))
+        self.assertEqual((0, 0), b._decode(0))  # pylint: disable=protected-access
+        encoded = b._abs_pos(3, 3)  # pylint: disable=protected-access
+        self.assertEqual((3, 3), b._decode(encoded))  # pylint: disable=protected-access

--- a/tests/test_bmp_indexed_load.py
+++ b/tests/test_bmp_indexed_load.py
@@ -40,7 +40,9 @@ class TestBmpIndexedLoad(TestCase):
         )
 
         bitmap, palette = load(
-            filename=test_file, bitmap=Bitmap_C_Interface, palette=Palette_C_Interface
+            file_or_filename=test_file,
+            bitmap=Bitmap_C_Interface,
+            palette=Palette_C_Interface,
         )
         self.assertTrue(isinstance(bitmap, Bitmap_C_Interface), bitmap)
         self.assertEqual(16, bitmap.colors)


### PR DESCRIPTION
Now we have to explicitly catch it.