### PR TITLE
Remove reassigning variables with new types, pass Mypy

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,5 +1,4 @@
 # SPDX-FileCopyrightText: 2020 Diego Elio Pettenò
-# SPDX-FileCopyrightText: 2023 Matt Land
 #
 # SPDX-License-Identifier: Unlicense
 
@@ -41,16 +40,3 @@ repos:
         files: "^tests/"
         args:
           - --disable=missing-docstring,consider-using-f-string,duplicate-code
-  - repo: local
-    hooks:
-      - id: mypy
-        name: mypy (library code)
-        entry: "mypy ."
-        language: python
-        additional_dependencies: ["mypy==1.2.0"]
-        types: [python]
-        exclude: "^(docs/|examples/|tests/|setup.py$)"
-        # use require_serial so that script
-        # is only called once per commit
-        require_serial: true
-        pass_filenames: false

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,4 +1,5 @@
 # SPDX-FileCopyrightText: 2020 Diego Elio Pettenò
+# SPDX-FileCopyrightText: 2023 Matt Land
 #
 # SPDX-License-Identifier: Unlicense
 
@@ -40,3 +41,16 @@ repos:
         files: "^tests/"
         args:
           - --disable=missing-docstring,consider-using-f-string,duplicate-code
+  - repo: local
+    hooks:
+      - id: mypy
+        name: mypy (library code)
+        entry: "mypy ."
+        language: python
+        additional_dependencies: ["mypy==1.2.0"]
+        types: [python]
+        exclude: "^(docs/|examples/|tests/|setup.py$)"
+        # use require_serial so that script
+        # is only called once per commit
+        require_serial: true
+        pass_filenames: false

--- a/adafruit_imageload/__init__.py
+++ b/adafruit_imageload/__init__.py
@@ -1,5 +1,5 @@
 # SPDX-FileCopyrightText: 2018 Scott Shawcroft for Adafruit Industries
-# SPDX-FileCopyrightText: 2022 Matt Land
+# SPDX-FileCopyrightText: 2022-2023 Matt Land
 #
 # SPDX-License-Identifier: MIT
 
@@ -77,10 +77,15 @@ def load(
 
             return pnm.load(file, header, bitmap=bitmap, palette=palette)
         if header.startswith(b"GIF"):
+            if not bitmap:
+                raise RuntimeError("bitmap argument required")
+
             from . import gif
 
             return gif.load(file, bitmap=bitmap, palette=palette)
         if header.startswith(b"\x89PN"):
+            if not bitmap:
+                raise RuntimeError("bitmap argument required")
             from . import png
 
             return png.load(file, bitmap=bitmap, palette=palette)

--- a/adafruit_imageload/bmp/__init__.py
+++ b/adafruit_imageload/bmp/__init__.py
@@ -1,5 +1,5 @@
 # SPDX-FileCopyrightText: 2018 Scott Shawcroft for Adafruit Industries
-# SPDX-FileCopyrightText: 2022 Matt Land
+# SPDX-FileCopyrightText: 2022-2023 Matt Land
 #
 # SPDX-License-Identifier: MIT
 
@@ -29,9 +29,9 @@ __repo__ = "https://github.com/adafruit/Adafruit_CircuitPython_ImageLoad.git"
 def load(
     file: BufferedReader,
     *,
-    bitmap: BitmapConstructor = None,
-    palette: PaletteConstructor = None
-) -> Tuple[Bitmap, Optional[Palette]]:
+    bitmap: Optional[BitmapConstructor] = None,
+    palette: Optional[PaletteConstructor] = None
+) -> Tuple[Optional[Bitmap], Optional[Palette]]:
     """Loads a bmp image from the open ``file``.
 
     Returns tuple of bitmap object and palette object.

--- a/adafruit_imageload/gif.py
+++ b/adafruit_imageload/gif.py
@@ -1,5 +1,5 @@
 # SPDX-FileCopyrightText: 2019 Radomir Dopieralski for Adafruit Industries
-# SPDX-FileCopyrightText: 2022 Matt Land
+# SPDX-FileCopyrightText: 2022-2023 Matt Land
 #
 # SPDX-License-Identifier: MIT
 
@@ -32,7 +32,7 @@ def load(
     file: BufferedReader,
     *,
     bitmap: BitmapConstructor,
-    palette: PaletteConstructor = None
+    palette: Optional[PaletteConstructor] = None
 ) -> Tuple[Bitmap, Optional[Palette]]:
     """Loads a GIF image from the open ``file``.
 
@@ -50,6 +50,8 @@ def load(
         "<HHBBB", file.read(7)
     )
     if (flags & 0x80) != 0:
+        if not palette:
+            raise RuntimeError("palette argument required")
         palette_size = 1 << ((flags & 0x07) + 1)
         palette_obj = palette(palette_size)
         for i in range(palette_size):

--- a/adafruit_imageload/pnm/pbm_ascii.py
+++ b/adafruit_imageload/pnm/pbm_ascii.py
@@ -1,5 +1,5 @@
 # SPDX-FileCopyrightText: 2018 Scott Shawcroft for Adafruit Industries
-# SPDX-FileCopyrightText: 2022 Matt Land
+# SPDX-FileCopyrightText: 2022-2023 Matt Land
 # SPDX-FileCopyrightText: Brooke Storm
 # SPDX-FileCopyrightText: Sam McGahan
 #
@@ -32,7 +32,7 @@ def load(
     width: int,
     height: int,
     bitmap: Bitmap,
-    palette: Palette = None,
+    palette: Optional[Palette] = None,
 ) -> Tuple[Bitmap, Optional[Palette]]:
     """
     Load a P1 'PBM' ascii image into the displayio.Bitmap

--- a/adafruit_imageload/pnm/pbm_binary.py
+++ b/adafruit_imageload/pnm/pbm_binary.py
@@ -1,5 +1,5 @@
 # SPDX-FileCopyrightText: 2018 Scott Shawcroft for Adafruit Industries
-# SPDX-FileCopyrightText: 2022 Matt Land
+# SPDX-FileCopyrightText: 2022-2023 Matt Land
 # SPDX-FileCopyrightText: Brooke Storm
 # SPDX-FileCopyrightText: Sam McGahan
 #
@@ -31,7 +31,7 @@ def load(
     width: int,
     height: int,
     bitmap: Bitmap,
-    palette: Palette = None,
+    palette: Optional[Palette] = None,
 ) -> Tuple[Bitmap, Optional[Palette]]:
     """
     Load a P4 'PBM' binary image into the Bitmap

--- a/adafruit_imageload/pnm/pgm/__init__.py
+++ b/adafruit_imageload/pnm/pgm/__init__.py
@@ -1,5 +1,5 @@
 # SPDX-FileCopyrightText: 2018 Scott Shawcroft for Adafruit Industries
-# SPDX-FileCopyrightText: 2022 Matt Land
+# SPDX-FileCopyrightText: 2022-2023 Matt Land
 # SPDX-FileCopyrightText: Brooke Storm
 # SPDX-FileCopyrightText: Sam McGahan
 #
@@ -29,8 +29,8 @@ def load(
     magic_number: bytes,
     header: List[int],
     *,
-    bitmap: BitmapConstructor = None,
-    palette: PaletteConstructor = None
+    bitmap: Optional[BitmapConstructor] = None,
+    palette: Optional[PaletteConstructor] = None
 ) -> Tuple[Optional[Bitmap], Optional[Palette]]:
     """
     Perform the load of Netpbm greyscale images (P2, P5)

--- a/adafruit_imageload/pnm/pgm/ascii.py
+++ b/adafruit_imageload/pnm/pgm/ascii.py
@@ -1,5 +1,5 @@
 # SPDX-FileCopyrightText: 2018 Scott Shawcroft for Adafruit Industries
-# SPDX-FileCopyrightText: 2022 Matt Land
+# SPDX-FileCopyrightText: 2022-2023 Matt Land
 # SPDX-FileCopyrightText: Brooke Storm
 # SPDX-FileCopyrightText: Sam McGahan
 #
@@ -27,8 +27,8 @@ def load(
     file: BufferedReader,
     width: int,
     height: int,
-    bitmap: BitmapConstructor = None,
-    palette: PaletteConstructor = None,
+    bitmap: Optional[BitmapConstructor] = None,
+    palette: Optional[PaletteConstructor] = None,
 ) -> Tuple[Optional[Bitmap], Optional[Palette]]:
     """
     Load a PGM ascii file (P2)
@@ -46,11 +46,12 @@ def load(
             _palette_colors.add(int_pixel)
             pixel = bytearray()
         pixel += byte
+    palette_obj = None
     if palette:
-        palette = build_palette(palette, _palette_colors)  # type: Palette
+        palette_obj = build_palette(palette, _palette_colors)
+    bitmap_obj = None
     if bitmap:
-        bitmap = bitmap(width, height, len(_palette_colors))  # type: Bitmap
-        _palette_colors = list(_palette_colors)
+        bitmap_obj = bitmap(width, height, len(_palette_colors))
         file.seek(data_start)
         for y in range(height):
             for x in range(width):
@@ -61,8 +62,8 @@ def load(
                         break
                     pixel += byte
                 int_pixel = int("".join(["%c" % char for char in pixel]))
-                bitmap[x, y] = _palette_colors.index(int_pixel)
-    return bitmap, palette
+                bitmap_obj[x, y] = list(_palette_colors).index(int_pixel)
+    return bitmap_obj, palette_obj
 
 
 def build_palette(

--- a/adafruit_imageload/pnm/pgm/binary.py
+++ b/adafruit_imageload/pnm/pgm/binary.py
@@ -1,5 +1,5 @@
 # SPDX-FileCopyrightText: 2018 Scott Shawcroft for Adafruit Industries
-# SPDX-FileCopyrightText: 2022 Matt Land
+# SPDX-FileCopyrightText: 2022-2023 Matt Land
 # SPDX-FileCopyrightText: Brooke Storm
 # SPDX-FileCopyrightText: Sam McGahan
 #
@@ -15,7 +15,7 @@ Load pixel values (indices or colors) into a bitmap and colors into a palette.
 
 """
 try:
-    from typing import Tuple, Optional, Set, List
+    from typing import Tuple, Optional, Set
     from io import BufferedReader
     from displayio import Palette, Bitmap
     from ...displayio_types import PaletteConstructor, BitmapConstructor
@@ -27,8 +27,8 @@ def load(
     file: BufferedReader,
     width: int,
     height: int,
-    bitmap: BitmapConstructor = None,
-    palette: PaletteConstructor = None,
+    bitmap: Optional[BitmapConstructor] = None,
+    palette: Optional[PaletteConstructor] = None,
 ) -> Tuple[Optional[Bitmap], Optional[Palette]]:
     """
     Load a P5 format file (binary), handle PGM (greyscale)
@@ -40,17 +40,18 @@ def load(
         for pixel in data_line:
             palette_colors.add(pixel)
 
+    palette_obj = None
     if palette:
-        palette = build_palette(palette, palette_colors)  # type: Palette
+        palette_obj = build_palette(palette, palette_colors)
+    bitmap_obj = None
     if bitmap:
-        bitmap = bitmap(width, height, len(palette_colors))  # type: Bitmap
-        palette_colors = list(palette_colors)  # type: List[int]
+        bitmap_obj = bitmap(width, height, len(palette_colors))
         file.seek(data_start)
         for y in range(height):
             data_line = iter(bytes(file.read(width)))
             for x, pixel in enumerate(data_line):
-                bitmap[x, y] = palette_colors.index(pixel)
-    return bitmap, palette
+                bitmap_obj[x, y] = list(palette_colors).index(pixel)
+    return bitmap_obj, palette_obj
 
 
 def build_palette(

--- a/adafruit_imageload/pnm/ppm_ascii.py
+++ b/adafruit_imageload/pnm/ppm_ascii.py
@@ -1,5 +1,5 @@
 # SPDX-FileCopyrightText: 2018 Scott Shawcroft for Adafruit Industries
-# SPDX-FileCopyrightText: 2022 Matt Land
+# SPDX-FileCopyrightText: 2022-2023 Matt Land
 # SPDX-FileCopyrightText: Brooke Storm
 # SPDX-FileCopyrightText: Sam McGahan
 #
@@ -38,8 +38,8 @@ def load(
     file: BufferedReader,
     width: int,
     height: int,
-    bitmap: BitmapConstructor = None,
-    palette: PaletteConstructor = None,
+    bitmap: Optional[BitmapConstructor] = None,
+    palette: Optional[PaletteConstructor] = None,
 ) -> Tuple[Optional[Bitmap], Optional[Palette]]:
     """
     :param stream file: infile with the position set at start of data
@@ -55,27 +55,28 @@ def load(
     for triplet in read_three_colors(file):
         palette_colors.add(triplet)
 
+    palette_obj = None
     if palette:
-        palette = palette(len(palette_colors))  # type: Palette
+        palette_obj = palette(len(palette_colors))
         for counter, color in enumerate(palette_colors):
-            palette[counter] = color
+            palette_obj[counter] = color
+    bitmap_obj = None
     if bitmap:
         file.seek(data_start)
-        bitmap = bitmap(width, height, len(palette_colors))  # type: Bitmap
-        palette_colors = list(palette_colors)  # type: List[bytes]
+        bitmap_obj = bitmap(width, height, len(palette_colors))
         for y in range(height):
             for x in range(width):
                 for color in read_three_colors(file):
-                    bitmap[x, y] = palette_colors.index(color)
+                    bitmap_obj[x, y] = list(palette_colors).index(color)
                     break  # exit the inner generator
-    return bitmap, palette
+    return bitmap_obj, palette_obj
 
 
 def read_three_colors(file: BufferedReader) -> Iterator[bytes]:
     """
     Generator to read integer values from file, in groups of three.
     Each value can be len 1-3, for values 0 - 255, space padded.
-    :return tuple[int]:
+    :return Iterator[bytes]:
     """
     triplet = []  # type: List[int]
     color = bytearray()

--- a/adafruit_imageload/pnm/ppm_binary.py
+++ b/adafruit_imageload/pnm/ppm_binary.py
@@ -1,5 +1,5 @@
 # SPDX-FileCopyrightText: 2018 Scott Shawcroft for Adafruit Industries
-# SPDX-FileCopyrightText: 2022 Matt Land
+# SPDX-FileCopyrightText: 2022-2023 Matt Land
 # SPDX-FileCopyrightText: Brooke Storm
 # SPDX-FileCopyrightText: Sam McGahan
 #
@@ -31,11 +31,14 @@ def load(
     file: BufferedReader,
     width: int,
     height: int,
-    bitmap: BitmapConstructor = None,
-    palette: PaletteConstructor = None,
+    bitmap: Optional[BitmapConstructor] = None,
+    palette: Optional[PaletteConstructor] = None,
 ) -> Tuple[Optional[Bitmap], Optional[Palette]]:
-    """Load pixel values (indices or colors) into a bitmap and for a binary
-    ppm, return None for pallet."""
+    """
+    Load pixel values (indices or colors) into a bitmap and for a binary
+    ppm, return None for pallet.
+    """
+    # pylint: disable=too-many-locals
 
     data_start = file.tell()
     palette_colors = set()  # type: Set[Tuple[int, int, int]]
@@ -47,22 +50,23 @@ def load(
             # red, green, blue
             palette_colors.add((red, next(data_line), next(data_line)))
 
+    palette_obj = None
     if palette:
-        palette = palette(len(palette_colors))  # type: Palette
+        palette_obj = palette(len(palette_colors))
         for counter, color in enumerate(palette_colors):
-            palette[counter] = bytes(color)
+            palette_obj[counter] = bytes(color)
+    bitmap_obj = None
     if bitmap:
-        bitmap = bitmap(width, height, len(palette_colors))  # type: Bitmap
+        bitmap_obj = bitmap(width, height, len(palette_colors))
         file.seek(data_start)
-        palette_colors = list(palette_colors)  # type: List[Tuple[int, int, int]]
         for y in range(height):
             x = 0
             data_line = iter(bytes(file.read(line_size)))
             for red in data_line:
                 # red, green, blue
-                bitmap[x, y] = palette_colors.index(
+                bitmap_obj[x, y] = list(palette_colors).index(
                     (red, next(data_line), next(data_line))
                 )
                 x += 1
 
-    return bitmap, palette
+    return bitmap_obj, palette_obj

--- a/adafruit_imageload/tilegrid_inflator.py
+++ b/adafruit_imageload/tilegrid_inflator.py
@@ -1,5 +1,5 @@
 # SPDX-FileCopyrightText: 2022 Tim Cocks for Adafruit Industries
-# SPDX-FileCopyrightText: 2022 Matt Land
+# SPDX-FileCopyrightText: 2022-2023 Matt Land
 #
 # SPDX-License-Identifier: MIT
 
@@ -27,9 +27,9 @@ __repo__ = "https://github.com/adafruit/Adafruit_CircuitPython_ImageLoad.git"
 
 
 def inflate_tilegrid(
-    bmp_path: str = None,
+    bmp_path: Optional[str] = None,
     target_size: Tuple[int, int] = (3, 3),
-    tile_size: List[int] = None,
+    tile_size: Optional[List[int]] = None,
     transparent_index: Optional[Union[tuple, int]] = None,
     bmp_obj: Optional[OnDiskBitmap] = None,
     bmp_palette: Optional[Palette] = None,
@@ -39,8 +39,8 @@ def inflate_tilegrid(
     the center rows and columns.
 
     :param Optional[str] bmp_path: filepath to the 3x3 spritesheet bitmap file
-    :param Optional[tuple] target_size: desired size in tiles (target_width, target_height)
-    :param Optional[tuple] tile_size: size of the tiles in the 3x3 spritesheet. If
+    :param tuple[int, int] target_size: desired size in tiles (target_width, target_height)
+    :param Optional[List[int]] tile_size: size of the tiles in the 3x3 spritesheet. If
       None is used it will equally divide the width and height of the Bitmap by 3.
     :param Optional[Union[tuple, int]] transparent_index: a single index within the palette to
       make transparent, or a tuple of multiple indexes to make transparent

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2022 Matt Land
+# SPDX-FileCopyrightText: 2022-2023 Matt Land
 #
 # SPDX-License-Identifier: Unlicense
 [mypy]
@@ -6,3 +6,9 @@ python_version = 3.7
 disallow_untyped_defs = True
 disable_error_code = no-redef
 exclude = (examples|tests|setup.py|docs)
+
+[mypy-displayio]
+ignore_missing_imports = True
+
+[mypy-bitmaptools]
+ignore_missing_imports = True


### PR DESCRIPTION
## Changes:
- Minor fixes for "Local variable 'x' might be referenced before assignment" for [width, height] in png.py
- Make function documentation of parameters match type hints where they disagreed or looked out of date
- Fix in gif.py, png.py where optional arguments were assumed truthy (and called) (Mypy arg-type error)
- Function arguments that are optional are changed to be explicit instead of implicit (PEP 484)
before
`
def foo(some_arg: Tree = None):
`
after
`
def foo(some_Arg: Optional[Tree]  = None):
`
- references that were re-assigned with new types are removed (Mypy "assignment" errors). This was usually from callables to objects, but there are other examples fixed in this pr also. This was also super confusing to contributors.  (Issue #59 )

before:
```
if palette:
    palette = callable(...)  # type: Palette
...
return palette, bitmap
```
after:
```
palette_obj = None
if palette:
    palette_obj = callable(...)
...
return palette_obj, bitmap_obj
```

before:
```
palette_colors = set()
while something:
    palette.add(<observed color>)
if bitmap:
    palette_colors = list(palette_colors)  # type: List[int]
    bitmap_obj[x, y] = palette_colors.index(pixel)
```

after:
```
palette_colors = set()
while something:
    palette.add(<observed color>)
if bitmap:
    bitmap_obj[x, y] = list(palette_colors).index(pixel)
```


## Testing
```
pipenv shell
pipenv install requirements.txt
mypy .
> Success: no issues found in 16 source files
```