### PR TITLE
Png transparency

### DIFF
--- a/adafruit_imageload/png.py
+++ b/adafruit_imageload/png.py
@@ -48,7 +48,7 @@ def load(
     :param object palette: Type to store the palette. Must have API similar to
       `displayio.Palette`. Will be skipped if None.
     """
-    # pylint: disable=too-many-locals,too-many-branches
+    # pylint: disable=too-many-locals,too-many-branches, consider-using-enumerate, too-many-statements
     header = file.read(8)
     if header != b"\x89PNG\r\n\x1a\n":
         raise ValueError("Not a PNG file")
@@ -87,10 +87,12 @@ def load(
                 for i in range(pal_size):
                     pal[i] = file.read(3)
         elif chunk == b"tRNS":
-            trns_list = list(file.read(size))
-            indices = [i for i, x in enumerate(trns_list) if x == 0]
-            for index in indices:
-                pal.make_transparent(index)
+            if size > len(pal):
+                raise ValueError("More transparency entries than palette entries")
+            trns_data = file.read(size)
+            for i in range(len(trns_data)):
+                if trns_data[i] == 0:
+                    pal.make_transparent(i)
         elif chunk == b"IDAT":
             data.extend(file.read(size))
         elif chunk == b"IEND":

--- a/adafruit_imageload/png.py
+++ b/adafruit_imageload/png.py
@@ -61,6 +61,10 @@ def load(
     height = 0
     while True:
         size, chunk = struct.unpack(">I4s", file.read(8))
+        print("==================")
+        print(size)
+        print(chunk)
+        print('====================')
         if chunk == b"IHDR":
             (
                 width,
@@ -86,6 +90,9 @@ def load(
                 pal = palette(pal_size)
                 for i in range(pal_size):
                     pal[i] = file.read(3)
+        elif chunk == b"tRNS":
+            transparent = file.read(size)
+            print(transparent)
         elif chunk == b"IDAT":
             data.extend(file.read(size))
         elif chunk == b"IEND":

--- a/adafruit_imageload/png.py
+++ b/adafruit_imageload/png.py
@@ -61,10 +61,6 @@ def load(
     height = 0
     while True:
         size, chunk = struct.unpack(">I4s", file.read(8))
-        print("==================")
-        print(size)
-        print(chunk)
-        print('====================')
         if chunk == b"IHDR":
             (
                 width,
@@ -91,8 +87,10 @@ def load(
                 for i in range(pal_size):
                     pal[i] = file.read(3)
         elif chunk == b"tRNS":
-            transparent = file.read(size)
-            print(transparent)
+            trns_list = list(file.read(size))
+            indices = [i for i, x in enumerate(trns_list) if x == 0]
+            for index in indices:
+                pal.make_transparent(index)
         elif chunk == b"IDAT":
             data.extend(file.read(size))
         elif chunk == b"IEND":

--- a/adafruit_imageload/png.py
+++ b/adafruit_imageload/png.py
@@ -1,5 +1,6 @@
 # SPDX-FileCopyrightText: 2022 Radomir Dopieralski
 # SPDX-FileCopyrightText: 2023 Matt Land
+# SPDX-FileCopyrightText: 2024 Channing Ramos
 #
 # SPDX-License-Identifier: MIT
 
@@ -10,7 +11,7 @@
 Load pixel values (indices or colors) into a bitmap and colors into a palette
 from a PNG file.
 
-* Author(s): Radomir Dopieralski, Matt Land
+* Author(s): Radomir Dopieralski, Matt Land, Channing Ramos
 
 """
 

--- a/adafruit_imageload/png.py
+++ b/adafruit_imageload/png.py
@@ -94,6 +94,7 @@ def load(
             for i in range(len(trns_data)):
                 if trns_data[i] == 0:
                     pal.make_transparent(i)
+            del trns_data
         elif chunk == b"IDAT":
             data.extend(file.read(size))
         elif chunk == b"IEND":


### PR DESCRIPTION
Fixes #65

Handles reading of the chunk in the png file that handles transparency, the trns chunk. This data is based off of the palette indexes and simply indicates alpha values of 0 or 255. Index 0 in this chunk correlates to index 0 of the color palette and goes on from there.

This chunk can have fewer indexes than the palette, but it is not allowed to contain more. Because of this I implemented a ValueError to check for this, and provides a hopefully helpful message about what is specifically wrong. Without this the user will instead receive errors related to palette errors which will likely be confusing if you dont know whats going on under the hood when you load an image.

For performance checking I measured the average load time of 150 imageload calls on a test image: 120x120px, 256 color palette with transparency enabled for the first and last index as a sort of worst case scenario.

I settled on reading the entirety of the chunk at once into a list, then running a for loop through it looking for the interesting values, then setting the `Palette.make_transparent` with the correct index number(s). Reading the data into a list, then working on that list proved to be more efficient speed-wise rather than the alternative of reading a single byte at a time then working with that. Read times can add up quickly.

Using a `for` loop also proved to be faster than doing list comprehension or using `enumerate()` by a noticeable margin as well. It has a bonus side effect of keeping the code easy to understand.

Added the following to the pylint disable:

- `consider-using-enumerate`: I did consider it, but it wasnt the best option
- `too-many-statements`: The added `if` statements pushes over the limit of 50 statements, to 51. This could be avoided by removing the error check, but I feel it is important to include a useful error message.