### PR TITLE
fix skewed PNG images caused by 'memoryview' bitmap filling

### DIFF
--- a/adafruit_imageload/png.py
+++ b/adafruit_imageload/png.py
@@ -27,7 +27,6 @@ except ImportError:
 
 import struct
 import zlib
-from sys import implementation
 
 __version__ = "0.0.0-auto.0"
 __repo__ = "https://github.com/adafruit/Adafruit_CircuitPython_ImageLoad.git"

--- a/adafruit_imageload/png.py
+++ b/adafruit_imageload/png.py
@@ -108,7 +108,7 @@ def load(  # noqa: PLR0912, PLR0915, Too many branches, Too many statements
         bmp = bitmap(width, height, colors)
         mem = memoryview(bmp)
         for y in range(height):
-            # Adjust for Displayio.Bitmap filler to scanline at byte boundry
+            # Adjust for Displayio.Bitmap filler to scanline at 4-byte boundry
             filladj = y * ((4 - (width % 4)) % 4)
             dst = y * scanline + filladj
             src = y * (scanline + 1) + 1

--- a/adafruit_imageload/png.py
+++ b/adafruit_imageload/png.py
@@ -110,7 +110,7 @@ def load(  # noqa: PLR0912, PLR0915, Too many branches, Too many statements
         for y in range(height):
             dst = y * scanline
             src = y * (scanline + 1) + 1
-            if depth < 8 or width > 128:
+            if depth <= 8:
                 # Work around the bug in displayio.Bitmap
                 # https://github.com/adafruit/circuitpython/issues/6675
                 pixels_per_byte = 8 // depth

--- a/adafruit_imageload/png.py
+++ b/adafruit_imageload/png.py
@@ -122,7 +122,7 @@ def load(  # noqa: PLR0912, PLR0915, Too many branches, Too many statements
             workaround = False
 
         for y in range(height):
-            if (workaround):
+            if workaround:
                 # Work around the bug in displayio.Bitmap
                 # remove once CircuitPython 9.1 is no longer supported
                 # https://github.com/adafruit/circuitpython/issues/6675

--- a/adafruit_imageload/png.py
+++ b/adafruit_imageload/png.py
@@ -110,7 +110,7 @@ def load(  # noqa: PLR0912, PLR0915, Too many branches, Too many statements
         for y in range(height):
             dst = y * scanline
             src = y * (scanline + 1) + 1
-            if depth <= 8:
+            if depth < 8 or (depth == 8 and width % 4 != 0):
                 # Work around the bug in displayio.Bitmap
                 # https://github.com/adafruit/circuitpython/issues/6675
                 pixels_per_byte = 8 // depth

--- a/adafruit_imageload/png.py
+++ b/adafruit_imageload/png.py
@@ -112,7 +112,7 @@ def load(  # noqa: PLR0912, PLR0915, Too many branches, Too many statements
             filladj = y * ((4 - (width % 4)) % 4)
             dst = y * scanline + filladj
             src = y * (scanline + 1) + 1
-            if depth < 5:
+            if depth < 8:
                 # Work around the bugs in displayio.Bitmap
                 # The first should have been resolved by #9479
                 # https://github.com/adafruit/circuitpython/issues/6675

--- a/adafruit_imageload/png.py
+++ b/adafruit_imageload/png.py
@@ -110,7 +110,7 @@ def load(  # noqa: PLR0912, PLR0915, Too many branches, Too many statements
         for y in range(height):
             dst = y * scanline
             src = y * (scanline + 1) + 1
-            if width % 4 != 0:
+            if depth < 5 or width % 4 != 0:
                 # Work around the bugs in displayio.Bitmap
                 # The first should have been resolved by #9479
                 # https://github.com/adafruit/circuitpython/issues/6675

--- a/adafruit_imageload/png.py
+++ b/adafruit_imageload/png.py
@@ -115,12 +115,12 @@ def load(  # noqa: PLR0912, PLR0915, Too many branches, Too many statements
         if (
             (implementation[1][0] == 9 and implementation[1][1] < 2) or implementation[1][0] < 9
         ) and (depth < 8 or width % 4 != 0):
+            # Work around the bug in displayio.Bitmap
+            # remove once CircuitPython 9.1 is no longer supported
+            # https://github.com/adafruit/circuitpython/issues/6675
+            # https://github.com/adafruit/circuitpython/issues/9707
             src_b = 1
             for y in range(height):
-                # Work around the bug in displayio.Bitmap
-                # remove once CircuitPython 9.1 is no longer supported
-                # https://github.com/adafruit/circuitpython/issues/6675
-                # https://github.com/adafruit/circuitpython/issues/9707
                 for x in range(0, width, pixels_per_byte):
                     byte = data_bytes[src_b]
                     for pixel in range(pixels_per_byte):

--- a/adafruit_imageload/png.py
+++ b/adafruit_imageload/png.py
@@ -109,24 +109,10 @@ def load(  # noqa: PLR0912, PLR0915, Too many branches, Too many statements
         mem = memoryview(bmp)
         for y in range(height):
             # Adjust for Displayio.Bitmap filler to scanline at 4-byte boundry
-            filladj = y * ((4 - (width % 4)) % 4)
+            filladj = y * ((4 - (scanline % 4)) % 4)
             dst = y * scanline + filladj
             src = y * (scanline + 1) + 1
-            if depth < 8:
-                # Work around the bugs in displayio.Bitmap
-                # The first should have been resolved by #9479
-                # https://github.com/adafruit/circuitpython/issues/6675
-                # https://github.com/adafruit/circuitpython/issues/9707
-                pixels_per_byte = 8 // depth
-                for x in range(0, width, pixels_per_byte):
-                    byte = data_bytes[src]
-                    for pixel in range(pixels_per_byte):
-                        bmp[x + pixel, y] = (byte >> ((pixels_per_byte - pixel - 1) * depth)) & (
-                            (1 << depth) - 1
-                        )
-                    src += 1
-            else:
-                mem[dst : dst + scanline] = data_bytes[src : src + scanline]
+            mem[dst : dst + scanline] = data_bytes[src : src + scanline]
         return bmp, pal
     # RGB, RGBA or Grayscale
     import displayio

--- a/adafruit_imageload/png.py
+++ b/adafruit_imageload/png.py
@@ -117,9 +117,9 @@ def load(  # noqa: PLR0912, PLR0915, Too many branches, Too many statements
             # remove once CircuitPython 9.1 is no longer supported
             # https://github.com/adafruit/circuitpython/issues/6675
             # https://github.com/adafruit/circuitpython/issues/9707
-            if ((implementation[1][0] == 9 and implementation[1][1] < 2) or
-                implementation[1][0] < 9) and (depth < 8 or width % 4 != 0):
-            
+            if (
+                (implementation[1][0] == 9 and implementation[1][1] < 2) or implementation[1][0] < 9
+            ) and (depth < 8 or width % 4 != 0):
                 pixels_per_byte = 8 // depth
                 for x in range(0, width, pixels_per_byte):
                     byte = data_bytes[src]

--- a/adafruit_imageload/png.py
+++ b/adafruit_imageload/png.py
@@ -108,9 +108,11 @@ def load(  # noqa: PLR0912, PLR0915, Too many branches, Too many statements
         bmp = bitmap(width, height, colors)
         mem = memoryview(bmp)
         for y in range(height):
-            dst = y * scanline
+            # Adjust for Displayio.Bitmap filler to scanline at byte boundry
+            filladj = (y * ((4 - (width % 4)) % 4))
+            dst = y * scanline + filladj
             src = y * (scanline + 1) + 1
-            if depth < 5 or width % 4 != 0:
+            if depth < 5:
                 # Work around the bugs in displayio.Bitmap
                 # The first should have been resolved by #9479
                 # https://github.com/adafruit/circuitpython/issues/6675

--- a/adafruit_imageload/png.py
+++ b/adafruit_imageload/png.py
@@ -111,18 +111,12 @@ def load(  # noqa: PLR0912, PLR0915, Too many branches, Too many statements
         pixels_per_byte = 8 // depth
         # Adjust for Displayio.Bitmap filler to scanline at 4-byte boundry
         filladj = (4 - (scanline % 4)) % 4
-        dst = 0
         src = 1
-        src_b = 1
         if (
             (implementation[1][0] == 9 and implementation[1][1] < 2) or implementation[1][0] < 9
         ) and (depth < 8 or width % 4 != 0):
-            workaround = True
-        else:
-            workaround = False
-
-        for y in range(height):
-            if workaround:
+            src_b = 1
+            for y in range(height):
                 # Work around the bug in displayio.Bitmap
                 # remove once CircuitPython 9.1 is no longer supported
                 # https://github.com/adafruit/circuitpython/issues/6675
@@ -134,11 +128,14 @@ def load(  # noqa: PLR0912, PLR0915, Too many branches, Too many statements
                             (1 << depth) - 1
                         )
                     src_b += 1
-            else:
+                src += scanline + 1
+                src_b = src
+        else:
+            dst = 0
+            for y in range(height):
                 mem[dst : dst + scanline] = data_bytes[src : src + scanline]
                 dst += scanline + filladj
-            src += scanline + 1
-            src_b = src
+                src += scanline + 1
         return bmp, pal
     # RGB, RGBA or Grayscale
     import displayio

--- a/adafruit_imageload/png.py
+++ b/adafruit_imageload/png.py
@@ -110,9 +110,11 @@ def load(  # noqa: PLR0912, PLR0915, Too many branches, Too many statements
         for y in range(height):
             dst = y * scanline
             src = y * (scanline + 1) + 1
-            if depth < 8 or (depth == 8 and width % 4 != 0):
-                # Work around the bug in displayio.Bitmap
+            if width % 4 != 0:
+                # Work around the bugs in displayio.Bitmap
+                # The first should have been resolved by #9479
                 # https://github.com/adafruit/circuitpython/issues/6675
+                # https://github.com/adafruit/circuitpython/issues/9707
                 pixels_per_byte = 8 // depth
                 for x in range(0, width, pixels_per_byte):
                     byte = data_bytes[src]

--- a/adafruit_imageload/png.py
+++ b/adafruit_imageload/png.py
@@ -112,6 +112,21 @@ def load(  # noqa: PLR0912, PLR0915, Too many branches, Too many statements
             filladj = y * ((4 - (scanline % 4)) % 4)
             dst = y * scanline + filladj
             src = y * (scanline + 1) + 1
+            # Work around the bug in displayio.Bitmap - removed afer resolution
+            # however left here as comments because it's helpful in
+            # understanding the memoryview scanline and adjustment calculations
+            # https://github.com/adafruit/circuitpython/issues/6675
+            # https://github.com/adafruit/circuitpython/issues/9707
+            #
+            #    pixels_per_byte = 8 // depth
+            #    for x in range(0, width, pixels_per_byte):
+            #        byte = data_bytes[src]
+            #        for pixel in range(pixels_per_byte):
+            #            bmp[x + pixel, y] = (byte >> ((pixels_per_byte - pixel - 1) * depth)) & (
+            #                (1 << depth) - 1
+            #            )
+            #        src += 1
+            #
             mem[dst : dst + scanline] = data_bytes[src : src + scanline]
         return bmp, pal
     # RGB, RGBA or Grayscale

--- a/adafruit_imageload/png.py
+++ b/adafruit_imageload/png.py
@@ -107,8 +107,6 @@ def load(  # noqa: PLR0912, PLR0915, Too many branches, Too many statements
     if mode == 3:  # indexed
         bmp = bitmap(width, height, 1 << depth)
         pixels_per_byte = 8 // depth
-        # Adjust for Displayio.Bitmap filler to scanline at 4-byte boundry
-        filladj = (4 - (scanline % 4)) % 4
         src = 1
         src_b = 1
         pixmask = (1 << depth) - 1

--- a/adafruit_imageload/png.py
+++ b/adafruit_imageload/png.py
@@ -114,10 +114,15 @@ def load(  # noqa: PLR0912, PLR0915, Too many branches, Too many statements
         dst = 0
         src = 1
         src_b = 1
+        if (
+            (implementation[1][0] == 9 and implementation[1][1] < 2) or implementation[1][0] < 9
+        ) and (depth < 8 or width % 4 != 0):
+            workaround = True
+        else:
+            workaround = False
+
         for y in range(height):
-            if (
-                (implementation[1][0] == 9 and implementation[1][1] < 2) or implementation[1][0] < 9
-            ) and (depth < 8 or width % 4 != 0):
+            if (workaround):
                 # Work around the bug in displayio.Bitmap
                 # remove once CircuitPython 9.1 is no longer supported
                 # https://github.com/adafruit/circuitpython/issues/6675

--- a/adafruit_imageload/png.py
+++ b/adafruit_imageload/png.py
@@ -110,7 +110,7 @@ def load(  # noqa: PLR0912, PLR0915, Too many branches, Too many statements
         for y in range(height):
             dst = y * scanline
             src = y * (scanline + 1) + 1
-            if depth < 8:
+            if depth < 8 or width > 128:
                 # Work around the bug in displayio.Bitmap
                 # https://github.com/adafruit/circuitpython/issues/6675
                 pixels_per_byte = 8 // depth

--- a/adafruit_imageload/png.py
+++ b/adafruit_imageload/png.py
@@ -109,9 +109,6 @@ def load(  # noqa: PLR0912, PLR0915, Too many branches, Too many statements
         bmp = bitmap(width, height, colors)
         mem = memoryview(bmp)
         for y in range(height):
-            # Adjust for Displayio.Bitmap filler to scanline at 4-byte boundry
-            filladj = y * ((4 - (scanline % 4)) % 4)
-            dst = y * scanline + filladj
             src = y * (scanline + 1) + 1
             if (
                 (implementation[1][0] == 9 and implementation[1][1] < 2) or implementation[1][0] < 9
@@ -129,6 +126,9 @@ def load(  # noqa: PLR0912, PLR0915, Too many branches, Too many statements
                         )
                     src += 1
             else:
+                # Adjust for Displayio.Bitmap filler to scanline at 4-byte boundry
+                filladj = y * ((4 - (scanline % 4)) % 4)
+                dst = y * scanline + filladj
                 mem[dst : dst + scanline] = data_bytes[src : src + scanline]
         return bmp, pal
     # RGB, RGBA or Grayscale

--- a/adafruit_imageload/png.py
+++ b/adafruit_imageload/png.py
@@ -25,9 +25,9 @@ try:
 except ImportError:
     pass
 
-from sys import implementation
 import struct
 import zlib
+from sys import implementation
 
 __version__ = "0.0.0-auto.0"
 __repo__ = "https://github.com/adafruit/Adafruit_CircuitPython_ImageLoad.git"
@@ -113,13 +113,13 @@ def load(  # noqa: PLR0912, PLR0915, Too many branches, Too many statements
             filladj = y * ((4 - (scanline % 4)) % 4)
             dst = y * scanline + filladj
             src = y * (scanline + 1) + 1
-            # Work around the bug in displayio.Bitmap
-            # remove once CircuitPython 9.1 is no longer supported
-            # https://github.com/adafruit/circuitpython/issues/6675
-            # https://github.com/adafruit/circuitpython/issues/9707
             if (
                 (implementation[1][0] == 9 and implementation[1][1] < 2) or implementation[1][0] < 9
             ) and (depth < 8 or width % 4 != 0):
+                # Work around the bug in displayio.Bitmap
+                # remove once CircuitPython 9.1 is no longer supported
+                # https://github.com/adafruit/circuitpython/issues/6675
+                # https://github.com/adafruit/circuitpython/issues/9707
                 pixels_per_byte = 8 // depth
                 for x in range(0, width, pixels_per_byte):
                     byte = data_bytes[src]

--- a/adafruit_imageload/png.py
+++ b/adafruit_imageload/png.py
@@ -109,7 +109,7 @@ def load(  # noqa: PLR0912, PLR0915, Too many branches, Too many statements
         mem = memoryview(bmp)
         for y in range(height):
             # Adjust for Displayio.Bitmap filler to scanline at byte boundry
-            filladj = (y * ((4 - (width % 4)) % 4))
+            filladj = y * ((4 - (width % 4)) % 4)
             dst = y * scanline + filladj
             src = y * (scanline + 1) + 1
             if depth < 5:


### PR DESCRIPTION
~This PR implements the [fix #74](https://github.com/adafruit/Adafruit_CircuitPython_ImageLoad/pull/84/commits/349529978c607bc4added21642594a98d96babe6) workaround on images that have a width greater than 128 pixels.~

~I don't know if the PNG image format changes when the image width gets larger than 128 pixels or if there's some decoding error in the library but  this workaround seems to resolve the problem I'm seeing for PNG files with a width > 128 pixels.~

This PR adjust the memoryview copy used for mode 3 PNG images to avoid the skewing that occurred when the image width was not an even multiple of either 4 pixels (for 8 bit color), 8 pixels (for 4 bit color), 16 pixels (for 2 bit color) or 32 pixels (for 1 bit color).

128x128:
![sbob128](https://github.com/user-attachments/assets/4b7b0672-e1df-40b2-8105-9cefaa11a44a)

129x129:
![sbob129](https://github.com/user-attachments/assets/ec7fdbec-fbc9-47c3-a2f7-269a2fc5024b)

fixes #88