### PR TITLE
Fixed truecolor bmp not using provided bitmap constructor

### DIFF
--- a/adafruit_imageload/bmp/truecolor.py
+++ b/adafruit_imageload/bmp/truecolor.py
@@ -94,7 +94,7 @@ def load(  # noqa: PLR0912, PLR0913, Too many branches, Too many arguments in fu
 
             # convert unsigned int to signed int when height is negative
             height = negative_height_check(height)
-        bitmap_obj = Bitmap(width, abs(height), 65535)
+        bitmap_obj = bitmap(width, abs(height), 65535)
         file.seek(data_start)
         line_size = width * (color_depth // 8)
         # Set the seek direction based on whether the height value is negative or positive


### PR DESCRIPTION
Noticed that this function always seemed to return a vanilla `display.io` Bitmap despite being provided a custom constructor. Looked into the source and discovered that the custom constructor was being ignored. 👍
Presto chango, the typo is now fixed.