### PR TITLE
Colorconvert in docstring

### DIFF
--- a/adafruit_imageload/__init__.py
+++ b/adafruit_imageload/__init__.py
@@ -24,7 +24,7 @@ try:
         Union,
     )
 
-    from displayio import Bitmap, Palette
+    from displayio import Bitmap, ColorConverter, Palette
 
     from .displayio_types import BitmapConstructor, PaletteConstructor
 except ImportError:
@@ -39,7 +39,7 @@ def load(
     *,
     bitmap: Optional[BitmapConstructor] = None,
     palette: Optional[PaletteConstructor] = None,
-) -> Tuple[Bitmap, Optional[Palette]]:
+) -> Tuple[Bitmap, Optional[Union[Palette, ColorConverter]]]:
     """Load pixel values (indices or colors) into a bitmap and colors into a palette.
 
     bitmap is the desired type. It must take width, height and color_depth in the constructor. It

--- a/adafruit_imageload/bmp/__init__.py
+++ b/adafruit_imageload/bmp/__init__.py
@@ -35,7 +35,8 @@ def load(
 ) -> Tuple[Optional[Bitmap], Optional[Union[Palette, ColorConverter]]]:
     """Loads a bmp image from the open ``file``.
 
-    Returns tuple of bitmap object and palette object.
+    Returns tuple of `displayio.Bitmap` object and
+    `displayio.Palette` object, or `displayio.ColorConverter` object.
 
     :param io.BufferedReader file: Open file handle or compatible (like `io.BytesIO`)
       with the data of a BMP file.

--- a/adafruit_imageload/bmp/__init__.py
+++ b/adafruit_imageload/bmp/__init__.py
@@ -15,9 +15,9 @@ Load pixel values (indices or colors) into a bitmap and colors into a palette fr
 
 try:
     from io import BufferedReader
-    from typing import List, Optional, Set, Tuple
+    from typing import List, Optional, Set, Tuple, Union
 
-    from displayio import Bitmap, Palette
+    from displayio import Bitmap, ColorConverter, Palette
 
     from ..displayio_types import BitmapConstructor, PaletteConstructor
 except ImportError:
@@ -32,7 +32,7 @@ def load(
     *,
     bitmap: Optional[BitmapConstructor] = None,
     palette: Optional[PaletteConstructor] = None,
-) -> Tuple[Optional[Bitmap], Optional[Palette]]:
+) -> Tuple[Optional[Bitmap], Optional[Union[Palette, ColorConverter]]]:
     """Loads a bmp image from the open ``file``.
 
     Returns tuple of bitmap object and palette object.


### PR DESCRIPTION
Resolves #80 

Documented that ColorConverter can be returned from `load()` in addition to Palette.

Screenshot of the updated sections of the docs:
![image](https://github.com/user-attachments/assets/237328c8-af4e-40af-bf14-2399c432f9f0)
