### PR TITLE
move prev,line swap to after putting data into bitmap

### DIFF
--- a/adafruit_imageload/png.py
+++ b/adafruit_imageload/png.py
@@ -168,7 +168,6 @@ def load(  # noqa: PLR0912, PLR0915, Too many branches, Too many statements
                 src += 1
         else:
             raise ValueError("Wrong filter.")
-        prev, line = line, prev
         if mode in (0, 4):  # grayscale
             for x in range(width):
                 c = line[x * unit]
@@ -180,5 +179,8 @@ def load(  # noqa: PLR0912, PLR0915, Too many branches, Too many statements
                 )
         else:
             raise ValueError("Unsupported color mode.")
+
+        prev, line = line, prev
+
     pal = displayio.ColorConverter(input_colorspace=displayio.Colorspace.RGB565)
     return bmp, pal


### PR DESCRIPTION
@ladyada 

Resolves: #91 

This swap of `prev` and `line` was prior to data from `line` being inserted into the Bitmap. That resulted in the first row being blank because `prev` was  empty on the first iteration. And led to the last row being "pushed off the bottom" and not rendered.

Fix tested on Feather S3 TFT  9.2.1 with this slightly modified reproducer from the issue:
```
import displayio
import adafruit_imageload

import board
display = board.DISPLAY

display.root_group = displayio.Group(scale=4)

image, palette = adafruit_imageload.load(f"test_pattern.png")
display.root_group.append(displayio.TileGrid(image, pixel_shader=palette, x=2, y=2))

bmp_image, bmp_palette = adafruit_imageload.load(f"test_pattern.bmp")
display.root_group.append(displayio.TileGrid(bmp_image, pixel_shader=bmp_palette, x=20, y=2))

while True:
    pass
```