### PR TITLE
Guard against out of bounds pixel set

### DIFF
--- a/adafruit_imageload/png.py
+++ b/adafruit_imageload/png.py
@@ -113,7 +113,10 @@ def load(  # noqa: PLR0912, PLR0915, Too many branches, Too many statements
             for x in range(0, width, pixels_per_byte):
                 byte = data_bytes[src_b]
                 for pixel in range(pixels_per_byte):
-                    bmp[x + pixel, y] = (byte >> ((pixels_per_byte - pixel - 1) * depth)) & pixmask
+                    if x + pixel < width:
+                        bmp[x + pixel, y] = (
+                            byte >> ((pixels_per_byte - pixel - 1) * depth)
+                        ) & pixmask
                 src_b += 1
             src += scanline + 1
             src_b = src


### PR DESCRIPTION
Resolves: #95 

I've tested successfully with the image file in the issue, as well as all PNGs included in the examples directory in this repo all on a PyPortal Titano `9.2.4`