### PR TITLE
Fix BMP truecolor loader to honor 4-byte row padding

### DIFF
--- a/adafruit_imageload/bmp/truecolor.py
+++ b/adafruit_imageload/bmp/truecolor.py
@@ -97,6 +97,10 @@ def load(  # noqa: PLR0912, PLR0913, Too many branches, Too many arguments in fu
         bitmap_obj = bitmap(width, abs(height), 65535)
         file.seek(data_start)
         line_size = width * (color_depth // 8)
+        # BMP scan lines are padded to a 4-byte boundary on disk; account
+        # for that padding so subsequent row reads stay aligned.
+        if line_size % 4 != 0:
+            line_size += 4 - line_size % 4
         # Set the seek direction based on whether the height value is negative or positive
         if height > 0:
             range1 = height - 1

--- a/tests/displayio_shared_bindings.py
+++ b/tests/displayio_shared_bindings.py
@@ -81,8 +81,12 @@ class Bitmap_C_Interface:
             return
         if not isinstance(value, (int)):
             raise RuntimeError(f"set value as int, not {type(value)}")
-        if value > 255:
-            raise ValueError(f"pixel value {value} too large")
+        # Cap at the wider of the legacy 8-bit limit (kept for backward
+        # compatibility with existing indexed-bitmap tests) or the
+        # bitmap's bits_per_value (needed for 16-bit truecolor bitmaps).
+        max_value = max(255, (1 << self._bits_per_value) - 1)
+        if value > max_value:
+            raise ValueError(f"pixel value {value} too large for {self._bits_per_value}-bit bitmap")
         if self.data.get(key):
             raise ValueError(f"pixel {self._decode(key)}/{key} already set, cannot set again")
         self.data[key] = value

--- a/tests/test_bmp_truecolor_load.py
+++ b/tests/test_bmp_truecolor_load.py
@@ -1,0 +1,209 @@
+# SPDX-FileCopyrightText: 2026 Melissa LeBlanc-Williams for Adafruit Industries
+#
+# SPDX-License-Identifier: MIT
+"""
+`adafruit_imageload.tests.test_bmp_truecolor_load`
+==================================================
+
+Regression coverage for ``adafruit_imageload.bmp.truecolor``.
+
+The original loader did not honour the 4-byte scan-line padding that the
+BMP format requires, so 24-bit BMPs whose ``width * 3`` is not a multiple
+of 4 (e.g. 125x125) loaded with row drift and scrambled colors.
+
+* Author(s): Melissa LeBlanc-Williams
+
+"""
+
+import os
+import struct
+import tempfile
+from unittest import TestCase
+
+from adafruit_imageload import load
+
+from .displayio_shared_bindings import Bitmap_C_Interface
+
+
+def _write_truecolor_bmp(path, pixels_topdown, width, height):
+    """Write a 24-bit BMP with the given top-down RGB888 pixel list.
+
+    ``pixels_topdown`` is a flat list of (R, G, B) tuples in row-major
+    top-down order (i.e. the first ``width`` entries are the top row).
+    The BMP file itself stores rows bottom-up with 4-byte row padding.
+    """
+    row_bytes = width * 3
+    pad = (4 - row_bytes % 4) % 4
+    data = bytearray()
+    # BMP rows are stored bottom-up.
+    for row_idx in range(height - 1, -1, -1):
+        row_start = row_idx * width
+        for px in range(width):
+            r, g, b = pixels_topdown[row_start + px]
+            # BMP byte order is B, G, R.
+            data.extend((b, g, r))
+        data.extend(b"\x00" * pad)
+
+    dib = struct.pack(
+        "<IiiHHIIiiII",
+        40,  # DIB header size (BITMAPINFOHEADER)
+        width,
+        height,  # positive => bottom-up storage
+        1,  # planes
+        24,  # bpp
+        0,  # BI_RGB (no compression)
+        len(data),
+        2835,
+        2835,
+        0,
+        0,
+    )
+    data_offset = 14 + 40
+    file_size = data_offset + len(data)
+    hdr = b"BM" + struct.pack("<IHHI", file_size, 0, 0, data_offset)
+    with open(path, "wb") as fp:
+        fp.write(hdr + dib + data)
+
+
+# RGB888 colors used in the fixtures.
+RED = (255, 0, 0)
+GREEN = (0, 255, 0)
+BLUE = (0, 0, 255)
+WHITE = (255, 255, 255)
+BLACK = (0, 0, 0)
+YELLOW = (255, 255, 0)
+
+# Their RGB565 representations (R5 G6 B5).
+RGB565_RED = 0xF800
+RGB565_GREEN = 0x07E0
+RGB565_BLUE = 0x001F
+RGB565_WHITE = 0xFFFF
+RGB565_BLACK = 0x0000
+RGB565_YELLOW = 0xFFE0
+
+
+class TestBmpTruecolorLoad(TestCase):
+    def test_24bit_no_row_padding(self):
+        """Width 4 -> row stride 12 bytes, already 4-byte aligned."""
+        # 4x2 image, row 0 (top): RED GREEN BLUE WHITE
+        #           row 1 (bot): BLACK YELLOW RED GREEN
+        pixels = [RED, GREEN, BLUE, WHITE, BLACK, YELLOW, RED, GREEN]
+        with tempfile.NamedTemporaryFile(suffix=".bmp", delete=False) as tmp:
+            path = tmp.name
+        try:
+            _write_truecolor_bmp(path, pixels, 4, 2)
+            bitmap, _ = load(file_or_filename=path, bitmap=Bitmap_C_Interface)
+        finally:
+            os.unlink(path)
+
+        self.assertEqual(4, bitmap.width)
+        self.assertEqual(2, bitmap.height)
+        expected = [
+            RGB565_RED,
+            RGB565_GREEN,
+            RGB565_BLUE,
+            RGB565_WHITE,
+            RGB565_BLACK,
+            RGB565_YELLOW,
+            RGB565_RED,
+            RGB565_GREEN,
+        ]
+        for idx, want in enumerate(expected):
+            x, y = idx % 4, idx // 4
+            self.assertEqual(
+                want, bitmap[x, y], f"pixel ({x},{y}) want 0x{want:04x} got 0x{bitmap[x, y]:04x}"
+            )
+
+    def test_24bit_row_padding_required(self):
+        """Width 3 -> row stride 9 bytes, needs 3 bytes of padding per row.
+
+        This is the regression test: prior to the fix, the second row read
+        would slide into the first row's padding bytes and the rest of the
+        image, scrambling all subsequent rows.
+        """
+        # 3x2 image, row 0 (top): WHITE BLACK YELLOW
+        #           row 1 (bot): RED   GREEN BLUE
+        pixels = [WHITE, BLACK, YELLOW, RED, GREEN, BLUE]
+        with tempfile.NamedTemporaryFile(suffix=".bmp", delete=False) as tmp:
+            path = tmp.name
+        try:
+            _write_truecolor_bmp(path, pixels, 3, 2)
+            bitmap, _ = load(file_or_filename=path, bitmap=Bitmap_C_Interface)
+        finally:
+            os.unlink(path)
+
+        self.assertEqual(3, bitmap.width)
+        self.assertEqual(2, bitmap.height)
+        expected = [
+            RGB565_WHITE,
+            RGB565_BLACK,
+            RGB565_YELLOW,
+            RGB565_RED,
+            RGB565_GREEN,
+            RGB565_BLUE,
+        ]
+        for idx, want in enumerate(expected):
+            x, y = idx % 3, idx // 3
+            self.assertEqual(
+                want, bitmap[x, y], f"pixel ({x},{y}) want 0x{want:04x} got 0x{bitmap[x, y]:04x}"
+            )
+
+    def test_24bit_odd_width_taller(self):
+        """Width 5 -> row stride 15 bytes, needs 1 byte of padding per row.
+
+        Uses 3 rows so any drift would compound, catching off-by-one fixes
+        that happen to work for 2-row inputs.
+        """
+        # 5x3, top-down:
+        #  row 0: RED   GREEN BLUE  WHITE BLACK
+        #  row 1: YELLOW RED   GREEN BLUE  WHITE
+        #  row 2: BLACK YELLOW RED   GREEN BLUE
+        pixels = [
+            RED,
+            GREEN,
+            BLUE,
+            WHITE,
+            BLACK,
+            YELLOW,
+            RED,
+            GREEN,
+            BLUE,
+            WHITE,
+            BLACK,
+            YELLOW,
+            RED,
+            GREEN,
+            BLUE,
+        ]
+        with tempfile.NamedTemporaryFile(suffix=".bmp", delete=False) as tmp:
+            path = tmp.name
+        try:
+            _write_truecolor_bmp(path, pixels, 5, 3)
+            bitmap, _ = load(file_or_filename=path, bitmap=Bitmap_C_Interface)
+        finally:
+            os.unlink(path)
+
+        self.assertEqual(5, bitmap.width)
+        self.assertEqual(3, bitmap.height)
+        expected_565 = [
+            RGB565_RED,
+            RGB565_GREEN,
+            RGB565_BLUE,
+            RGB565_WHITE,
+            RGB565_BLACK,
+            RGB565_YELLOW,
+            RGB565_RED,
+            RGB565_GREEN,
+            RGB565_BLUE,
+            RGB565_WHITE,
+            RGB565_BLACK,
+            RGB565_YELLOW,
+            RGB565_RED,
+            RGB565_GREEN,
+            RGB565_BLUE,
+        ]
+        for idx, want in enumerate(expected_565):
+            x, y = idx % 5, idx // 5
+            self.assertEqual(
+                want, bitmap[x, y], f"pixel ({x},{y}) want 0x{want:04x} got 0x{bitmap[x, y]:04x}"
+            )


### PR DESCRIPTION
The 24-bit BMP loader in `adafruit_imageload/bmp/truecolor.py` reads each
scan line as exactly `width * bytes_per_pixel` bytes and does not account
for the 4-byte row alignment that the BMP format requires on disk. For any
24-bit BMP whose width times 3 is not a multiple of 4, each subsequent row
read drifts by the cumulative padding amount and the resulting bitmap is
scrambled.

The indexed loader (`adafruit_imageload/bmp/indexed.py`) already pads
`line_size` up to a multiple of 4. This PR applies the same fix to the
truecolor loader.

## Reproducing the bug

Any 24-bit BMP whose width is not a multiple of 4 will hit this. A simple
case is a 3x2 BMP:

| width | row_bytes (w*3) | padding | stride on disk |
|-------|-----------------|---------|----------------|
| 100   | 300             | 0       | 300 (no drift) |
| 125   | 375             | 1       | 376            |
|   3   |   9             | 3       |  12            |

Before this PR, a 3x2 BMP whose top row is `WHITE BLACK YELLOW` and
bottom row is `RED GREEN BLUE` loads as:

```
row 0: 0x0000, 0xffff, 0x0000   # scrambled (BLACK, WHITE, BLACK)
row 1: 0xf800, 0x07e0, 0x001f   # RED, GREEN, BLUE (still correct -
                                # first row read from file)
```

After this PR, both rows load correctly:

```
row 0: 0xffff, 0x0000, 0xffe0   # WHITE, BLACK, YELLOW
row 1: 0xf800, 0x07e0, 0x001f   # RED, GREEN, BLUE
```

## Real-world impact

Originally surfaced on a CircuitPython sprite-on-background demo running
on a Qualia ESP32-S3 with a 480x480 dotclock TFT. The sprite was a
125x125 24-bit BMP exported from Photoshop. After this fix, the loaded
pixel values match the source bitmap exactly (verified against PIL's
RGB888 -> RGB565 quantization: zero mismatches across all 9079 opaque
pixels of the test sprite).

## Tests

Adds `tests/test_bmp_truecolor_load.py` with three regression tests:

- `test_24bit_no_row_padding` - width 4, no padding, baseline.
- `test_24bit_row_padding_required` - width 3, needs 3 bytes/row of
  padding. This is the direct regression for the reported bug.
- `test_24bit_odd_width_taller` - width 5, needs 1 byte/row, 3 rows
  tall so cumulative drift would compound and catch off-by-one fixes
  that happen to work for 2-row inputs.

The tests synthesise BMP files in-process via `tempfile` so no new
fixture files are added to the repo. The shared test stub
`Bitmap_C_Interface` was capped at value 255, too low for 16-bit
truecolor bitmaps; the cap is raised to honor the bitmap's own
`bits_per_value` while keeping the legacy 255 ceiling for the existing
1-bit/8-bit tests (`max(255, (1 << bits_per_value) - 1)`).

All 43 tests (40 existing + 3 new) pass. `pre-commit run --all-files`
clean (ruff-format, ruff, reuse).